### PR TITLE
Add type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "engines": {
     "node": ">=10"
   },
+  "types": "types/react-lottie-player.d.ts",
   "scripts": {
     "build": "microbundle-crl --no-compress --format modern,cjs",
     "start": "microbundle-crl watch --no-compress --format modern,cjs",

--- a/types/react-lottie-player.d.ts
+++ b/types/react-lottie-player.d.ts
@@ -1,0 +1,26 @@
+declare module 'react-lottie-player' {
+  const Lottie: React.FC<LottieProps>
+
+  interface LottieProps
+    extends React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLDivElement>,
+      HTMLDivElement
+    > {
+    animationData: object
+    play?: boolean
+    goTo?: number
+    speed?: number
+    direction?: 1 | -1
+    loop?: number | bool
+    segments?: Array<number> | boolean
+    props?: object
+    rendererSettings?: object
+    renderer?: string
+    onComplete?: function
+    onLoopComplete?: function
+    onEnterFrame?: function
+    onSegmentStart?: function
+  }
+
+  export default Lottie
+}


### PR DESCRIPTION
Added type definitions to be able to have auto-completion when using in Typescript.

Unfortunately I have noticed that microbundle won't include the type definitions
in the `dist` directory after building and I was unable to find a setting that
would allow for that. Any advice would be appreciated.

Closes #5
