### PR TITLE
Add /light module and type definitions for LottiePlayerLight

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install --save react-lottie-player
 import React from 'react'
 import Lottie from 'react-lottie-player'
 // Alternatively:
-// import Lottie from 'react-lottie-player/dist/LottiePlayerLight'
+// import Lottie from 'react-lottie-player/light'
 
 
 import lottieJson from './my-lottie.json'
@@ -64,7 +64,7 @@ const MyComponent = () => {
 
 ## LottiePlayerLight
 
-The default lottie player uses `eval`. If you don't want eval to be used in your code base, you can instead import `react-lottie-player/dist/LottiePlayerLight`. For more discussion see [#39](https://github.com/mifi/react-lottie-player/pull/39).
+The default lottie player uses `eval`. If you don't want eval to be used in your code base, you can instead import `react-lottie-player/light`. For more discussion see [#39](https://github.com/mifi/react-lottie-player/pull/39).
 
 See also [#11](https://github.com/mifi/react-lottie-player/issues/11)
 

--- a/example/src/Test.js
+++ b/example/src/Test.js
@@ -1,5 +1,5 @@
 import Lottie from 'react-lottie-player'
-import LottieLight from 'react-lottie-player/dist/LottiePlayerLight'
+import LottieLight from 'react-lottie-player/light'
 
 import React from 'react';
 

--- a/light/index.d.ts
+++ b/light/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from '../dist/LottiePlayerLight'
+export * from '../dist/LottiePlayerLight'

--- a/light/index.js
+++ b/light/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/LottiePlayerLight')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist && microbundle-crl src/LottiePlayer.js src/LottiePlayerLight.js --no-compress --format modern,cjs -o dist && cp src/index.d.ts dist",
+    "build": "rm -rf dist && microbundle-crl src/LottiePlayer.js src/LottiePlayerLight.js --no-compress --format modern,cjs -o dist && cp src/*.d.ts dist",
     "start": "rm -rf dist && microbundle-crl watch src/LottiePlayer.js src/LottiePlayerLight.js --no-compress --format modern,cjs -o dist",
     "prepare": "run-s build",
     "test": "run-s test:lint test:build test:unit",
@@ -49,7 +49,8 @@
     "wait-on": "^5.2.1"
   },
   "files": [
-    "dist"
+    "dist",
+    "light"
   ],
   "dependencies": {
     "fast-deep-equal": "^3.1.3",

--- a/src/LottiePlayerLight.d.ts
+++ b/src/LottiePlayerLight.d.ts
@@ -1,0 +1,3 @@
+import '.'
+export { default } from 'react-lottie-player'
+export * from 'react-lottie-player'


### PR DESCRIPTION
Fixes #45

Adds a type definition for `LottiePlayerLight` that reexports the `index.d.ts` types.

I have also added a `/light` module to simplify importing the light version and update the example and docs.  If you would prefer to leave this out of this PR, let me know and I'll remove it and leave just the type def.