### PR TITLE
update lottie-web to fix typescript type

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
     "lodash.clonedeep": "^4.5.0",
-    "lottie-web": "^5.7.6"
+    "lottie-web": "^5.7.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7204,10 +7204,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-web@^5.7.6:
-  version "5.7.6"
-  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.6.tgz#f20e5555ff120dc1e07ba53adb40061e822f3c48"
-  integrity sha512-qn/KYMI4QQvFDhtoxs0RPkn9uZKhDB9keE5BKgbJlSRfNEZpRiDlwBE9ibYz4nPhbyE+NUlt8IRIVR7g5OSX3w==
+lottie-web@^5.7.14:
+  version "5.7.14"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.14.tgz#cdabd256181c3ea64cf0c174a61dfa137228981f"
+  integrity sha512-J+QEPse7Rws0XvTqRJNtcE8cszb5FWYFHubEK6bgDJtw64/AQJ40aazbWXsWGBM4sm/PgLBLgmmhDU4QpLiieg==
 
 lower-case@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This commit updates lottie-web to the latest version.
Reason: audioFactory type defs were added in version 5.7.9 (merged commit preceding the release https://github.com/airbnb/lottie-web/commit/66ce9e1c147b9ee4dff3ef3b4576e60cafd5cd93). Currently the included version of lottie-web 5.7.6 is missing those types and thus typescript complains about missing prop audioFactory when creating a new Lottie object. 