### PR TITLE
Exported LottieProps type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ declare module 'react-lottie-player' {
     AnimationSegment
   } from 'lottie-web'
 
-  type LottieProps = React.DetailedHTMLProps<
+  export type LottieProps = React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > &


### PR DESCRIPTION
fixes #46

Small change to export the LottieProps type. It can now be imported by consumers of the library, using
```ts
import { LottieProps } from "react-lottie-player";
```
To verify:
- [ ] Versioning (not increment as part of this PR - is this required?)
- [ ] Tests (snapshot tests fail on my machine regardless of this change)