### PR TITLE
use rfdc instead of lodash.clonedeep for faster object cloning

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6414,11 +6414,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -8876,6 +8871,11 @@ rework@1.0.1:
   dependencies:
     convert-source-map "^0.3.3"
     css "^2.0.0"
+
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rgb-regex@^1.0.1:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "lodash.clonedeep": "^4.5.0",
-    "lottie-web": "^5.7.6"
+    "lottie-web": "^5.7.6",
+    "rfdc": "^1.3.0"
   }
 }

--- a/src/makeLottiePlayer.js
+++ b/src/makeLottiePlayer.js
@@ -1,7 +1,7 @@
 import React, { memo, useRef, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import equal from 'fast-deep-equal/es6/react'
-import cloneDeep from 'lodash.clonedeep'
+import clone from 'rfdc/default'
 
 const makeLottiePlayer = (lottie) => {
   const Lottie = memo(({
@@ -60,10 +60,10 @@ const makeLottiePlayer = (lottie) => {
         // https://github.com/mifi/react-lottie-player/issues/11#issuecomment-879310039
         // https://github.com/chenqingspring/vue-lottie/issues/20
         if (typeof animationData.default === 'object') {
-          return cloneDeep(animationData.default)
+          return clone(animationData.default)
         }
         // cloneDeep to prevent memory leak. See #35
-        return cloneDeep(animationData)
+        return clone(animationData)
       }
 
       // console.log('init')

--- a/yarn.lock
+++ b/yarn.lock
@@ -7137,11 +7137,6 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -9953,6 +9948,11 @@ rework@1.0.1:
   dependencies:
     convert-source-map "^0.3.3"
     css "^2.0.0"
+
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rgb-regex@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I know I'm really splitting hairs here, since what's being "boosted" is a one-off cloning operation, but free performance is like free beer, so why not? 

:beer: Cheers!