### PR TITLE
Match TS props to React PropTypes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@ declare module 'react-lottie-player' {
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > &
-    Pick<AnimationConfig, 'loop' | 'renderer' | 'rendererSettings' | 'audioFactory'> & {
+    Partial<Pick<AnimationConfig, 'loop' | 'renderer' | 'rendererSettings' | 'audioFactory'>> & {
       play?: boolean
       goTo?: number
       speed?: number


### PR DESCRIPTION
This PR marks some fields on the `LottieProps` type signature as Optional in order to match the React PropTypes.

In a TypeScript project, creating a LottiePlayer with only `animationData` will trigger this TypeScript error:

```
Type '{ animationData: Record<string, unknown>; play: boolean; loop: true; }' is missing the following properties from type 'Pick<any, "loop" | "renderer" | "rendererSettings" | "audioFactory">': renderer, rendererSettings, audioFactory
```

According to the [React PropTypes](https://github.com/mifi/react-lottie-player/blob/64eac186947be7ee5aad304ca4193c507ace8dc3/src/index.js#L147), the "missing" fields are not required and the component functions without them.