### PR TITLE
Add RendererType as type argument to AnimationConfig

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,14 +3,15 @@ declare module 'react-lottie-player' {
     AnimationConfig,
     AnimationDirection,
     AnimationEventCallback,
-    AnimationSegment
+    AnimationSegment,
+    RendererType
   } from 'lottie-web'
 
   export type LottieProps = React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > &
-    Partial<Pick<AnimationConfig, 'loop' | 'renderer' | 'rendererSettings' | 'audioFactory'>> & {
+    Partial<Pick<AnimationConfig<RendererType>, 'loop' | 'renderer' | 'rendererSettings' | 'audioFactory'>> & {
       play?: boolean
       goTo?: number
       speed?: number


### PR DESCRIPTION
This fixes a type error when trying to use either 'canvas' or 'html' as the value for the `renderer` prop

![image](https://github.com/mifi/react-lottie-player/assets/14058404/48ebfdcf-5435-4bc9-a741-eedd5ab8d95a)
