### PR TITLE
Fix the use of Pick type in type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,7 +12,7 @@ declare module 'react-lottie-player' {
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   >> &
-    Partial<Pick<AnimationConfig<RendererType>, 'path', 'animationData', 'loop' | 'renderer' | 'rendererSettings' | 'audioFactory'>> & {
+    Partial<Pick<AnimationConfig<RendererType>, 'loop' | 'renderer' | 'rendererSettings' | 'audioFactory'>> & {
       play?: boolean
       goTo?: number
       speed?: number


### PR DESCRIPTION
This change was originally made in #111. Pick type only takes two parameters: https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys

The keys should be unioned with `|`. `'path'` and `'animationData'` are separated with `,` which makes them invalid. They also don't need to be picked from `AnimationConfig` since we already add them in explicitly.